### PR TITLE
Device Size Limit is 2.147GB

### DIFF
--- a/perl/mib_lvm.pl
+++ b/perl/mib_lvm.pl
@@ -119,7 +119,7 @@ sub getnext {
 }
 
 sub get_vg_info {
-    open (FILE , "sudo /usr/sbin/vgs --noheadings -o vg_name,vg_size,lv_count,vg_extent_size,vg_extent_count,vg_free_count --units b|") || return undef ;
+    open (FILE , "sudo vgs --noheadings -o vg_name,vg_size,lv_count,vg_extent_size,vg_extent_count,vg_free_count --units k|") || return undef ;
     my ( @vgname , @vgs ) ;
 
     while (my $row = <FILE>) {
@@ -128,10 +128,10 @@ sub get_vg_info {
 
         my ($vg_name, $vg_size, $lv_count, $vg_extent_size, $vg_extent_count, $vg_free_count) = split(/\s+/, $row);
 
-        $vg_size =~ s/B//;
+        $vg_size =~ s/k//;
         $vg_size = int($vg_size);
 
-        $vg_extent_size =~ s/B//;
+        $vg_extent_size =~ s/k//;
         $vg_extent_size = int($vg_extent_size);
 
         $vg_extent_count = int($vg_extent_count);
@@ -154,7 +154,7 @@ sub get_vg_info {
 sub get_all_lvs  {
     my @lvs = ();
 
-    open (FILE , "sudo lvs --noheadings -o lv_name,vg_name,lv_size,origin --units b|") || return undef ;
+    open (FILE , "sudo lvs --noheadings -o lv_name,vg_name,lv_size,origin --units k|") || return undef ;
 
     while (my $row = <FILE>) {
         $row = trim($row);
@@ -162,7 +162,7 @@ sub get_all_lvs  {
 
         my ($lv_name, $vg_name, $lv_size, $origin) = split(/\s+/, $row);
 
-        $lv_size =~ s/B//;
+        $lv_size =~ s/k//;
         $lv_size = int($lv_size);
 
         my %lv = (


### PR DESCRIPTION
Using Bytes as Size for the VG/LV's result in a maximum Device Size of about 2GB while using signed 32Bit Integer Value.
Using kB instead increase the maximun VG/LV Size to ~2TB which is still far to low for modern Systems but good enough for a quick fix.

Maybe it would be usefull to use Gauge32 as an unsigned Integer to increase max Volume Size to ~4TB

Additionally i've removed the path to the vgs binary, as the path is wrong for RHEL/CentOS and probably many others.